### PR TITLE
Fix PHP version detection in CI workflow to handle ^8.1 correctly

### DIFF
--- a/.github/workflows/php-ci.yml
+++ b/.github/workflows/php-ci.yml
@@ -58,7 +58,7 @@ jobs:
         run: |
           PHP_VERSION=$(jq -r '.require.php' composer.json)
           echo "PHP version found in composer.json: $PHP_VERSION"
-          PHP_VERSION_MAJOR_MINOR=$(echo "$PHP_VERSION" | sed -E 's/^\^([0-9]+\.[0-9]+)\.0$/\1/')
+          PHP_VERSION_MAJOR_MINOR=$(echo "$PHP_VERSION" | sed -E 's/^\^?([0-9]+\.[0-9]+)(\.[0-9]+)?$/\1/')
           echo "PHP version (major.minor): $PHP_VERSION_MAJOR_MINOR"
           echo "php_version=$PHP_VERSION_MAJOR_MINOR" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
# AB#5634

**Author Checklist**

- I have tested the code in this PR myself
- I have removed debugging code from this branch
- I have added an AB ticket number to this PR
- I have addressed any errors raised by the Github Workflows
- I have moved the AB ticket into `Dev Done`

**Reviewer Checklist**

- I have moved the AB ticket into `Code Review Doing`
