### PR TITLE
Update php-ci.yml

### DIFF
--- a/.github/workflows/php-ci.yml
+++ b/.github/workflows/php-ci.yml
@@ -58,7 +58,7 @@ jobs:
         run: |
           PHP_VERSION=$(jq -r '.require.php' composer.json)
           echo "PHP version found in composer.json: $PHP_VERSION"
-          PHP_VERSION_MAJOR_MINOR=$(echo "$PHP_VERSION" | sed -E 's/^\^?([0-9]+\.[0-9]+)(\.[0-9]+)?$/\1/')
+          PHP_VERSION_MAJOR_MINOR=$(echo "$PHP_VERSION" | sed -E 's/^\^?([0-9]+\.[0-9]+).*/\1/')
           echo "PHP version (major.minor): $PHP_VERSION_MAJOR_MINOR"
           echo "php_version=$PHP_VERSION_MAJOR_MINOR" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
Update the PHP version regex to accept a complex constraint for PHP version. e.g.

```
"require": {
    "php": "^7.3|^8.0",
    ...
}
```

Also maintains backward compatibility

# AB#

**Author Checklist**

- I have tested the code in this PR myself
- I have removed debugging code from this branch
- I have added an AB ticket number to this PR
- I have addressed any errors raised by the Github Workflows
- I have moved the AB ticket into `Dev Done`

**Reviewer Checklist**

- I have moved the AB ticket into `Code Review Doing`
